### PR TITLE
Update versions of Python being tested against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
 - 3.6-dev
 - '3.7'
 - 3.7-dev
-- 3.8-dev
-- nightly
+# - 3.8-dev
+# - nightly
 env:
 - PIPENV_IGNORE_VIRTUALENVS=1
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 - 3.6-dev
 - '3.7'
 - 3.7-dev
+- 3.8-dev
 - nightly
 env:
 - PIPENV_IGNORE_VIRTUALENVS=1


### PR DESCRIPTION
Build is currently failing due to some issue with Python 3.8 beta.

This fixes that by ignoring Python 3.8.